### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/layz_spa/manifest.json
+++ b/custom_components/layz_spa/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "layz_spa",
   "name": "Lay-Z Spa",
+  "version": "1.0.0",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/layz_spa",
   "requirements": ["layz-spa==0.4"],


### PR DESCRIPTION
Add  "version": "1.0.0", 
Issue #11 : This is a Warning from HA Systme / Core Log :
WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'layz_spa'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'layz_spa'